### PR TITLE
Fix duplicate post display on home page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,7 +87,7 @@ const getLink = (post: any) => {
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-    {sortedPosts.map((post) => {
+    {sortedPosts.slice(1).map((post) => {
       const link = getLink(post);
       const title = post.frontmatter.title || getLink(post);
       const date = new Date(post.frontmatter.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });


### PR DESCRIPTION
- Exclude latest post from blog listing since it's already featured
- Use slice(1) to skip first post in the grid display